### PR TITLE
fix(51224): Go-to-definition on continue and break should jump around(?) corresponding statement

### DIFF
--- a/tests/cases/fourslash/goToDefinitionForBreak1.ts
+++ b/tests/cases/fourslash/goToDefinitionForBreak1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/for (;;) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", `end`);

--- a/tests/cases/fourslash/goToDefinitionForBreak2.ts
+++ b/tests/cases/fourslash/goToDefinitionForBreak2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////for (;;) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForBreak3.ts
+++ b/tests/cases/fourslash/goToDefinitionForBreak3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/for (;;) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForBreak4.ts
+++ b/tests/cases/fourslash/goToDefinitionForBreak4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: for (;;) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForBreak5.ts
+++ b/tests/cases/fourslash/goToDefinitionForBreak5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: for (;;) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForBreak6.ts
+++ b/tests/cases/fourslash/goToDefinitionForBreak6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: for (;;) {
+////  test: for (;;) {
+////    [|/*start*/break|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForBreak7.ts
+++ b/tests/cases/fourslash/goToDefinitionForBreak7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////for (;;) {
+////  /*end*/for (;;) {
+////    [|/*start*/break|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForContinue1.ts
+++ b/tests/cases/fourslash/goToDefinitionForContinue1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/for (;;) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", `end`);

--- a/tests/cases/fourslash/goToDefinitionForContinue2.ts
+++ b/tests/cases/fourslash/goToDefinitionForContinue2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////for (;;) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForContinue3.ts
+++ b/tests/cases/fourslash/goToDefinitionForContinue3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/for (;;) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForContinue4.ts
+++ b/tests/cases/fourslash/goToDefinitionForContinue4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: for (;;) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForContinue5.ts
+++ b/tests/cases/fourslash/goToDefinitionForContinue5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: for (;;) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForContinue6.ts
+++ b/tests/cases/fourslash/goToDefinitionForContinue6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: for (;;) {
+////  test: for (;;) {
+////    [|/*start*/continue|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForContinue7.ts
+++ b/tests/cases/fourslash/goToDefinitionForContinue7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////for (;;) {
+////  /*end*/for (;;) {
+////    [|/*start*/continue|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInBreak1.ts
+++ b/tests/cases/fourslash/goToDefinitionForInBreak1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/for (let a in obj) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", `end`);

--- a/tests/cases/fourslash/goToDefinitionForInBreak2.ts
+++ b/tests/cases/fourslash/goToDefinitionForInBreak2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a in obj) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForInBreak3.ts
+++ b/tests/cases/fourslash/goToDefinitionForInBreak3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/for (let a in obj) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInBreak4.ts
+++ b/tests/cases/fourslash/goToDefinitionForInBreak4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: for (let a in obj) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInBreak5.ts
+++ b/tests/cases/fourslash/goToDefinitionForInBreak5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: for (let a in obj) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForInBreak6.ts
+++ b/tests/cases/fourslash/goToDefinitionForInBreak6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: for (let a in obj) {
+////  test: for (let a in obj) {
+////    [|/*start*/break|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInBreak7.ts
+++ b/tests/cases/fourslash/goToDefinitionForInBreak7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a in obj) {
+////  /*end*/for (let a in obj) {
+////    [|/*start*/break|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInContinue1.ts
+++ b/tests/cases/fourslash/goToDefinitionForInContinue1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/for (let a in obj) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", `end`);

--- a/tests/cases/fourslash/goToDefinitionForInContinue2.ts
+++ b/tests/cases/fourslash/goToDefinitionForInContinue2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a in obj) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForInContinue3.ts
+++ b/tests/cases/fourslash/goToDefinitionForInContinue3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/for (let a in obj) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInContinue4.ts
+++ b/tests/cases/fourslash/goToDefinitionForInContinue4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: for (let a in obj) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInContinue5.ts
+++ b/tests/cases/fourslash/goToDefinitionForInContinue5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: for (let a in obj) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForInContinue6.ts
+++ b/tests/cases/fourslash/goToDefinitionForInContinue6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: for (let a in obj) {
+////  test: for (let a in obj) {
+////    [|/*start*/continue|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForInContinue7.ts
+++ b/tests/cases/fourslash/goToDefinitionForInContinue7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a in obj) {
+////  /*end*/for (let a in obj) {
+////    [|/*start*/continue|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfBreak1.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfBreak1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/for (let a of obj) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", `end`);

--- a/tests/cases/fourslash/goToDefinitionForOfBreak2.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfBreak2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a of obj) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForOfBreak3.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfBreak3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/for (let a of obj) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfBreak4.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfBreak4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: for (let a of obj) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfBreak5.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfBreak5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: for (let a of obj) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForOfBreak6.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfBreak6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: for (let a of obj) {
+////  test: for (let a of obj) {
+////    [|/*start*/break|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfBreak7.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfBreak7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a of obj) {
+////  /*end*/for (let a of obj) {
+////    [|/*start*/break|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfContinue1.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfContinue1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/for (let a of obj) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", `end`);

--- a/tests/cases/fourslash/goToDefinitionForOfContinue2.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfContinue2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a of obj) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForOfContinue3.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfContinue3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/for (let a of obj) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfContinue4.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfContinue4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: for (let a of obj) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfContinue5.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfContinue5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: for (let a of obj) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionForOfContinue6.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfContinue6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: for (let a of obj) {
+////  test: for (let a of obj) {
+////    [|/*start*/continue|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionForOfContinue7.ts
+++ b/tests/cases/fourslash/goToDefinitionForOfContinue7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////for (let a of obj) {
+////  /*end*/for (let a of obj) {
+////    [|/*start*/continue|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchBreak1.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchBreak1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/switch (null) {
+////  case null: [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchBreak2.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchBreak2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////switch (null) {
+////  case null: [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionSwitchBreak3.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchBreak3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/switch (null) {
+////  case null: [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchBreak4.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchBreak4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: switch (null) {
+////  case null: [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchBreak5.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchBreak5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: switch (null) {
+////  case null: [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionSwitchBreak6.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchBreak6.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: switch (null) {
+////  case null: {
+////    test: switch (null) {
+////      case null: [|/*start*/break|] label;
+////    }
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchBreak7.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchBreak7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////switch (null) {
+////  case null: /*end*/switch (null) {
+////    case null: [|/*start*/break|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchContinue1.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchContinue1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////switch (null) {
+////  case null: [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionSwitchContinue2.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchContinue2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////switch (null) {
+////  case null: [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionSwitchContinue3.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchContinue3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: switch (null) {
+////  case null: [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionSwitchContinue4.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchContinue4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: switch (null) {
+////  case null: [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchContinue5.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchContinue5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: switch (null) {
+////  case null: [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionSwitchContinue6.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchContinue6.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: switch (null) {
+////  case null: {
+////    test: switch (null) {
+////      case null: [|/*start*/continue|] label;
+////    }
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionSwitchContinue7.ts
+++ b/tests/cases/fourslash/goToDefinitionSwitchContinue7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////switch (null) {
+////  case null: switch (null) {
+////    case null: [|/*start*/continue|];
+////  }
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionWhileBreak1.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileBreak1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/while (true) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileBreak2.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileBreak2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////while (true) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionWhileBreak3.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileBreak3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/while (true) {
+////  [|/*start*/break|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileBreak4.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileBreak4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: while (true) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileBreak5.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileBreak5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: while (true) {
+////  [|/*start*/break|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionWhileBreak6.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileBreak6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: while (true) {
+////  test: while (true) {
+////    [|/*start*/break|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileBreak7.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileBreak7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////while (true) {
+////  /*end*/while (true) {
+////    [|/*start*/break|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileContinue1.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileContinue1.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/while (true) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileContinue2.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileContinue2.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////while (true) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionWhileContinue3.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileContinue3.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////test: /*end*/while (true) {
+////  [|/*start*/continue|];
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileContinue4.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileContinue4.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/test: while (true) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileContinue5.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileContinue5.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////label: while (true) {
+////  [|/*start*/continue|] test;
+////}
+
+verify.goToDefinition("start", []);

--- a/tests/cases/fourslash/goToDefinitionWhileContinue6.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileContinue6.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+/////*end*/label: while (true) {
+////  test: while (true) {
+////    [|/*start*/continue|] label;
+////  }
+////}
+
+verify.goToDefinition("start", "end");

--- a/tests/cases/fourslash/goToDefinitionWhileContinue7.ts
+++ b/tests/cases/fourslash/goToDefinitionWhileContinue7.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+////while (true) {
+////  /*end*/while (true) {
+////    [|/*start*/continue|];
+////  }
+////}
+
+verify.goToDefinition("start", "end");


### PR DESCRIPTION
Fixes #51224
